### PR TITLE
Add high level test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/tests/FunctionsHighLevelTest.php
+++ b/tests/FunctionsHighLevelTest.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__ . '/../includes/Functions.php';
+require_once __DIR__ . '/../includes/php/FunctionsMBString.php';
+require_once __DIR__ . '/../includes/php/FunctionsPreg.php';
+
+use PHPUnit\Framework\TestCase;
+
+class FunctionsHighLevelTest extends TestCase {
+    private $f;
+
+    protected function setUp(): void {
+        $this->f = ABJ_404_Solution_Functions::getInstance();
+    }
+
+    public function testSanitizeTextFieldRecursive() {
+        if (!function_exists('sanitize_text_field')) {
+            function sanitize_text_field($str) {
+                return trim(strip_tags($str));
+            }
+        }
+        $input = [
+            'a' => ' <b>Hello</b> ',
+            'b' => [
+                'c' => "<script>alert('x')</script> test"
+            ]
+        ];
+        $expected = [
+            'a' => 'Hello',
+            'b' => [
+                'c' => "alert('x') test"
+            ]
+        ];
+        $this->assertSame($expected, $this->f->sanitize_text_field_recursive($input));
+    }
+
+    public function testEscapeForXSS() {
+        $input = '<script>alert("x")</script>';
+        $result = $this->f->escapeForXSS($input);
+        $this->assertSame('scriptalertx/script', $result);
+    }
+
+    public function testSingleStrReplaceAndNullReplacement() {
+        $this->assertSame('foo  bar', $this->f->str_replace('x', null, 'foo x bar'));
+        $this->assertSame('baz baz bar', $this->f->single_str_replace('foo', 'baz', 'foo foo bar'));
+    }
+
+    public function testFileSystemHelpers() {
+        $base = ABJ404_PATH . 'testDir';
+        $sub = $base . '/sub';
+        $file = $sub . '/file.txt';
+        $this->f->createDirectoryWithErrorMessages($sub);
+        file_put_contents($file, 'data');
+        $this->assertFileExists($file);
+        ABJ_404_Solution_Functions::safeUnlink($file);
+        $this->assertFileDoesNotExist($file);
+        $this->assertTrue(ABJ_404_Solution_Functions::deleteDirectoryRecursively($base));
+        $this->assertDirectoryDoesNotExist($base);
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,19 @@
 <?php
+if (!defined('ABSPATH')) {
+    define('ABSPATH', sys_get_temp_dir() . '/wp/');
+    if (!is_dir(ABSPATH)) {
+        mkdir(ABSPATH, 0777, true);
+    }
+}
+if (!defined('ABJ404_PATH')) {
+    define('ABJ404_PATH', sys_get_temp_dir() . '/abj404_test/');
+    if (!is_dir(ABJ404_PATH)) {
+        mkdir(ABJ404_PATH, 0777, true);
+    }
+}
+if (!defined('ABJ404_PP')) {
+    define('ABJ404_PP', 'abj404_solution');
+}
 require_once __DIR__ . '/../includes/Functions.php';
 require_once __DIR__ . '/../includes/php/FunctionsMBString.php';
 require_once __DIR__ . '/../includes/php/FunctionsPreg.php';


### PR DESCRIPTION
## Summary
- add bootstrap constants for testing
- add extra function tests covering sanitization, escaping and FS helpers
- ignore PHPUnit result cache

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_683f53d139c08328a6cf4b62dd7d8761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to validate text sanitization, string manipulation, and file system helper utilities.
  - Improved test setup to ensure necessary directories and constants are defined for testing.

- **Chores**
  - Updated configuration to ignore PHPUnit result cache files, preventing them from being tracked by version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->